### PR TITLE
fix: optimize basehub queries #116

### DIFF
--- a/apps/web/src/app/(site)/about/page.tsx
+++ b/apps/web/src/app/(site)/about/page.tsx
@@ -19,8 +19,8 @@ export default async function About() {
   });
 
   const pages = blogPosts.map((post) => ({
-    href: `/blog/${post._slug}`,
-    title: post._title,
+    href: `/blog/${post._sys.slug}`,
+    title: post._sys.title,
     description: post.metaDescription,
     readMoreButtonText: post.readMoreButtonText,
   }));

--- a/apps/web/src/app/(site)/about/page.tsx
+++ b/apps/web/src/app/(site)/about/page.tsx
@@ -13,7 +13,7 @@ import { PageIntro } from '#/ui/page-intro';
 import { PageLinks } from '#/ui/page-links';
 import { StatList, StatListItem } from '#/ui/stat-list';
 
-export default async function About() {
+export default async function AboutPage() {
   const { items: blogPosts } = await fetchBlogPosts({
     first: 2,
   });

--- a/apps/web/src/app/(site)/accessibility/page.tsx
+++ b/apps/web/src/app/(site)/accessibility/page.tsx
@@ -17,7 +17,7 @@ import { PageIntro } from '#/ui/page-intro';
 import { PageLinks } from '#/ui/page-links';
 import RichTextWrapper from '#/ui/shared/rich-text-wrapper';
 
-export default async function PrivacyPolicy() {
+export default async function AccessibilityPage() {
   const pageIntro = await fetchAccessibilityPageIntro();
   const privacy = await fetchAccessibilityPage();
   const { items: blogPosts } = await fetchBlogPosts({

--- a/apps/web/src/app/(site)/accessibility/page.tsx
+++ b/apps/web/src/app/(site)/accessibility/page.tsx
@@ -25,8 +25,8 @@ export default async function PrivacyPolicy() {
   });
 
   const pages = blogPosts.map((post) => ({
-    href: `/blog/${post._slug}`,
-    title: post._title,
+    href: `/blog/${post._sys.slug}`,
+    title: post._sys.title,
     description: post.metaDescription,
     readMoreButtonText: post.readMoreButtonText,
   }));

--- a/apps/web/src/app/(site)/ai-blog/[slug]/page.tsx
+++ b/apps/web/src/app/(site)/ai-blog/[slug]/page.tsx
@@ -48,7 +48,7 @@ const AiBlogPost = async ({ params }: { params: { slug: string } }) => {
   });
 
   const filteredAiBlogPosts = moreAiBlogPosts.filter(
-    (morePost) => morePost._id !== post._id,
+    (morePost) => morePost._sys.id !== post._sys.id,
   );
 
   const limitedAiBlogPosts = filteredAiBlogPosts.slice(0, 2);
@@ -59,13 +59,13 @@ const AiBlogPost = async ({ params }: { params: { slug: string } }) => {
         <FadeIn>
           <header className="mx-auto flex max-w-5xl flex-col text-center">
             <h1 className="mt-6 font-mono text-4xl font-semibold tracking-tighter text-foreground [text-wrap:balance] sm:text-5xl">
-              {post._title}
+              {post._sys.title}
             </h1>
             <time
-              dateTime={post.publishedDate}
+              dateTime={post._sys.createdAt}
               className="order-first block font-mono text-sm font-bold uppercase tracking-widest text-primary"
             >
-              {formatDate(post.publishedDate)}
+              {formatDate(post._sys.createdAt)}
             </time>
             <div className="mt-6 flex items-center justify-center space-x-2">
               <Image
@@ -79,13 +79,13 @@ const AiBlogPost = async ({ params }: { params: { slug: string } }) => {
                 className="h-6 w-6 flex-none rounded-full bg-background grayscale transition duration-500 hover:grayscale-0 motion-safe:hover:scale-105"
               />
               <span className="font-mono text-sm font-medium tracking-tighter text-secondary-foreground">
-                {post.company._title}
+                {post.company._sys.title}
               </span>
               <span className="text-sm text-secondary-foreground">::</span>
               <span className="font-mono text-xs font-medium uppercase tracking-tighter text-primary">
                 {post.category.length > 0 && (
                   <div className="font-mono text-xs font-medium uppercase text-primary">
-                    #{post.category[0]?._title}
+                    #{post.category[0]?._sys.title}
                   </div>
                 )}
               </span>
@@ -106,9 +106,9 @@ const AiBlogPost = async ({ params }: { params: { slug: string } }) => {
           className="mt-24 sm:mt-32 lg:mt-40"
           title="More articles"
           pages={limitedAiBlogPosts.map((post) => ({
-            href: `/ai-blog/${post._slug}`,
-            date: post.publishedDate,
-            title: post._title,
+            href: `/ai-blog/${post._sys.slug}`,
+            date: post._sys.createdAt,
+            title: post._sys.title,
             description: post.metaDescription,
             readMoreButtonText: post.readMoreButtonText,
           }))}

--- a/apps/web/src/app/(site)/ai-blog/[slug]/page.tsx
+++ b/apps/web/src/app/(site)/ai-blog/[slug]/page.tsx
@@ -104,7 +104,7 @@ const AiBlogPost = async ({ params }: { params: { slug: string } }) => {
       {limitedAiBlogPosts.length > 0 && (
         <PageLinks
           className="mt-24 sm:mt-32 lg:mt-40"
-          title="More articles"
+          title="More from the AI blog "
           pages={limitedAiBlogPosts.map((post) => ({
             href: `/ai-blog/${post._sys.slug}`,
             date: post._sys.createdAt,

--- a/apps/web/src/app/(site)/ai-blog/page.tsx
+++ b/apps/web/src/app/(site)/ai-blog/page.tsx
@@ -50,21 +50,21 @@ export default async function AiBlog() {
         >
           <LoadMoreItems>
             {initialAiBlogPosts.map((aiPost) => (
-              <FadeIn key={aiPost._id}>
+              <FadeIn key={aiPost._sys.id}>
                 <article>
                   <Border className="pt-16">
                     <div className="relative lg:-mx-4 lg:flex lg:justify-end">
                       <div className="pt-10 lg:w-2/3 lg:flex-none lg:px-4 lg:pt-0">
                         <h2 className="max-w-2xl text-pretty font-mono text-3xl font-semibold leading-normal tracking-tighter text-foreground hover:text-primary">
-                          <Link href={`/ai-blog/${aiPost._slug}`}>
-                            {aiPost._title}
+                          <Link href={`/ai-blog/${aiPost._sys.slug}`}>
+                            {aiPost._sys.title}
                           </Link>
                         </h2>
                         <dl className="lg:absolute lg:left-0 lg:top-0 lg:w-1/3 lg:px-4">
                           <dt className="sr-only">Published</dt>
                           <dd className="absolute left-0 top-0 font-mono text-sm uppercase lg:static">
-                            <time dateTime={aiPost.publishedDate}>
-                              {formatDate(aiPost.publishedDate)}
+                            <time dateTime={aiPost._sys.createdAt}>
+                              {formatDate(aiPost._sys.createdAt)}
                             </time>
                           </dd>
                           <dt className="sr-only">LLM Model</dt>
@@ -83,7 +83,7 @@ export default async function AiBlog() {
                             </div>
                             <div className="text-sm text-secondary-foreground">
                               <div className="font-mono font-medium tracking-tighter">
-                                {aiPost.company._title}
+                                {aiPost.company._sys.title}
                               </div>
                               <div className="font-mono text-muted-foreground">
                                 <span className="text-alternate">
@@ -97,8 +97,8 @@ export default async function AiBlog() {
                           {aiPost.metaDescription}
                         </p>
                         <Link
-                          href={`/ai-blog/${aiPost._slug}`}
-                          aria-label={`Read more: ${aiPost._title}`}
+                          href={`/ai-blog/${aiPost._sys.slug}`}
+                          aria-label={`Read more: ${aiPost._sys.title}`}
                           className={cn(
                             buttonVariants({
                               variant: 'secondary',

--- a/apps/web/src/app/(site)/ai-blog/page.tsx
+++ b/apps/web/src/app/(site)/ai-blog/page.tsx
@@ -24,7 +24,7 @@ import { Container } from '#/ui/page-container';
 import { PageIntro } from '#/ui/page-intro';
 import { LoadMore, LoadMoreButton, LoadMoreItems } from '#/ui/shared/load-more';
 
-export default async function AiBlog() {
+export default async function AiBlogPage() {
   const { items: initialAiBlogPosts, totalCount } = await fetchAiBlogPosts({
     skip: 0,
     first: 10,

--- a/apps/web/src/app/(site)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(site)/blog/[slug]/page.tsx
@@ -105,7 +105,7 @@ const BlogPostPage = async ({ params }: { params: { slug: string } }) => {
       {limitedBlogPosts.length > 0 && (
         <PageLinks
           className="mt-24 sm:mt-32 lg:mt-40"
-          title="More articles"
+          title="More from the blog"
           pages={limitedBlogPosts.map((post) => ({
             href: `/blog/${post._sys.slug}`,
             date: post._sys.createdAt,

--- a/apps/web/src/app/(site)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(site)/blog/[slug]/page.tsx
@@ -32,7 +32,7 @@ export async function generateStaticParams() {
   return blog.blogPosts.items.map((post) => ({ params: { slug: post._slug } }));
 }
 
-const BlogPost = async ({ params }: { params: { slug: string } }) => {
+const BlogPostPage = async ({ params }: { params: { slug: string } }) => {
   const { blog } = await basehubClient.query(getPostBySlugQuery(params.slug));
   const post = blog.blogPosts.items[0];
   if (!post) notFound();
@@ -121,7 +121,7 @@ const BlogPost = async ({ params }: { params: { slug: string } }) => {
   );
 };
 
-export default BlogPost;
+export default BlogPostPage;
 
 export async function generateMetadata({
   params,

--- a/apps/web/src/app/(site)/blog/[slug]/page.tsx
+++ b/apps/web/src/app/(site)/blog/[slug]/page.tsx
@@ -41,7 +41,7 @@ const BlogPost = async ({ params }: { params: { slug: string } }) => {
   });
 
   const filteredBlogPosts = moreBlogPosts.filter(
-    (morePost) => morePost._id !== post._id,
+    (morePost) => morePost._sys.id !== post._sys.id,
   );
 
   const limitedBlogPosts = filteredBlogPosts.slice(0, 2);
@@ -52,30 +52,30 @@ const BlogPost = async ({ params }: { params: { slug: string } }) => {
         <FadeIn>
           <header className="mx-auto flex max-w-5xl flex-col text-center">
             <h1 className="mt-6 font-mono text-4xl font-semibold tracking-tighter text-foreground [text-wrap:balance] sm:text-5xl">
-              {post._title}
+              {post._sys.title}
             </h1>
             <time
-              dateTime={post.publishedDate}
+              dateTime={post._sys.createdAt}
               className="order-first block font-mono text-sm font-bold uppercase tracking-widest text-primary"
             >
-              {formatDate(post.publishedDate)}
+              {formatDate(post._sys.createdAt)}
             </time>
             <div className="mt-6 flex items-center justify-center space-x-2">
               <Image
                 src={post.author.image.url}
                 width={48}
                 height={48}
-                alt={`Image of ${post.author._title}`}
+                alt={`Image of ${post.author._sys.title}`}
                 className="h-6 w-6 flex-none rounded-full bg-background grayscale transition duration-500 hover:grayscale-0 motion-safe:hover:scale-105"
               />
               <span className="font-mono text-sm font-medium tracking-tighter text-secondary-foreground">
-                {post.author._title}
+                {post.author._sys.title}
               </span>
               <span className="text-sm text-secondary-foreground">::</span>
               <span className="font-mono text-xs font-medium uppercase tracking-tighter text-primary">
                 {post.category.length > 0 && (
                   <div className="font-mono text-xs font-medium uppercase text-primary">
-                    #{post.category[0]?._title}
+                    #{post.category[0]?._sys.title}
                   </div>
                 )}
               </span>
@@ -90,7 +90,7 @@ const BlogPost = async ({ params }: { params: { slug: string } }) => {
         />
         <AuthorCard
           author={{
-            name: post.author._title,
+            name: post.author._sys.title,
             role: post.author.role,
             imageUrl: post.author.image.url,
             imageAlt: post.author.image.alt ?? 'An image of the author',
@@ -107,9 +107,9 @@ const BlogPost = async ({ params }: { params: { slug: string } }) => {
           className="mt-24 sm:mt-32 lg:mt-40"
           title="More articles"
           pages={limitedBlogPosts.map((post) => ({
-            href: `/blog/${post._slug}`,
-            date: post.publishedDate,
-            title: post._title,
+            href: `/blog/${post._sys.slug}`,
+            date: post._sys.createdAt,
+            title: post._sys.title,
             description: post.metaDescription,
             readMoreButtonText: post.readMoreButtonText,
           }))}

--- a/apps/web/src/app/(site)/blog/page.tsx
+++ b/apps/web/src/app/(site)/blog/page.tsx
@@ -50,7 +50,7 @@ export default async function Blog() {
         >
           <LoadMoreItems>
             {initialBlogPosts.map((post) => (
-              <FadeIn key={post._id}>
+              <FadeIn key={post._sys.id}>
                 <article>
                   <Border className="pt-16">
                     <div className="relative lg:-mx-4 lg:flex lg:justify-end">
@@ -58,20 +58,20 @@ export default async function Blog() {
                         <div className="mb-2 font-mono text-sm font-medium uppercase text-primary">
                           {post.category.length > 0 && (
                             <div className="mb-2 font-mono text-sm font-medium uppercase text-primary">
-                              #{post.category[0]?._title}
+                              #{post.category[0]?._sys.title}
                             </div>
                           )}
                         </div>
                         <h2 className="max-w-2xl text-pretty font-mono text-3xl font-semibold leading-normal tracking-tighter text-foreground hover:text-primary">
-                          <Link href={`/blog/${post._slug}`}>
-                            {post._title}
+                          <Link href={`/blog/${post._sys.slug}`}>
+                            {post._sys.title}
                           </Link>
                         </h2>
                         <dl className="lg:absolute lg:left-0 lg:top-0 lg:w-1/3 lg:px-4">
                           <dt className="sr-only">Published</dt>
                           <dd className="absolute left-0 top-0 font-mono text-sm uppercase lg:static">
-                            <time dateTime={post.publishedDate}>
-                              {formatDate(post.publishedDate)}
+                            <time dateTime={post._sys.createdAt}>
+                              {formatDate(post._sys.createdAt)}
                             </time>
                           </dd>
                           <dt className="sr-only">Author</dt>
@@ -90,7 +90,7 @@ export default async function Blog() {
                             </div>
                             <div className="text-sm text-secondary-foreground">
                               <div className="font-mono font-medium tracking-tighter">
-                                {post.author._title}
+                                {post.author._sys.title}
                               </div>
                               <div className="font-mono text-muted-foreground">
                                 <span className="text-alternate">
@@ -105,8 +105,8 @@ export default async function Blog() {
                         </div>
 
                         <Link
-                          href={post._slug}
-                          aria-label={`Read more: ${post._title}`}
+                          href={`/blog/${post._sys.slug}`}
+                          aria-label={`Read more: ${post._sys.title}`}
                           className={cn(
                             buttonVariants({
                               variant: 'secondary',

--- a/apps/web/src/app/(site)/blog/page.tsx
+++ b/apps/web/src/app/(site)/blog/page.tsx
@@ -24,7 +24,7 @@ import { Container } from '#/ui/page-container';
 import { PageIntro } from '#/ui/page-intro';
 import { LoadMore, LoadMoreButton, LoadMoreItems } from '#/ui/shared/load-more';
 
-export default async function Blog() {
+export default async function BlogPage() {
   const { items: initialBlogPosts, totalCount } = await fetchBlogPosts({
     skip: 0,
     first: 10,

--- a/apps/web/src/app/(site)/clients/page.tsx
+++ b/apps/web/src/app/(site)/clients/page.tsx
@@ -7,7 +7,7 @@ import { ContactSection } from '#/ui/contact-section';
 import { PageLinks } from '#/ui/page-links';
 import ComingSoon from '#/ui/shared/coming-soon';
 
-export default async function Clients() {
+export default async function ClientsPage() {
   const { items: blogPosts } = await fetchBlogPosts({
     first: 2,
   });

--- a/apps/web/src/app/(site)/clients/page.tsx
+++ b/apps/web/src/app/(site)/clients/page.tsx
@@ -13,8 +13,8 @@ export default async function Clients() {
   });
 
   const pages = blogPosts.map((post) => ({
-    href: `/blog/${post._slug}`,
-    title: post._title,
+    href: `/blog/${post._sys.slug}`,
+    title: post._sys.title,
     description: post.metaDescription,
     readMoreButtonText: post.readMoreButtonText,
   }));

--- a/apps/web/src/app/(site)/contact/page.tsx
+++ b/apps/web/src/app/(site)/contact/page.tsx
@@ -8,7 +8,7 @@ import Locations from '#/ui/contact/locations';
 import { Container } from '#/ui/page-container';
 import { PageIntro } from '#/ui/page-intro';
 
-export default function Contact() {
+export default function ContactPage() {
   return (
     <>
       <PageIntro eyebrow="Contact us" title="Drop us a line">
@@ -28,7 +28,7 @@ export default function Contact() {
   );
 }
 
-const title = 'Contact';
+const title = 'ContactPage';
 const description =
   "Wanna contact the us at sambi.dev? 😎 Slide into our Upwork DMs if you're new or hit us up on GitHub if you're not. We're totally stoked to hear from you. 🤙";
 

--- a/apps/web/src/app/(site)/editorial/page.tsx
+++ b/apps/web/src/app/(site)/editorial/page.tsx
@@ -17,7 +17,7 @@ import { PageIntro } from '#/ui/page-intro';
 import { PageLinks } from '#/ui/page-links';
 import RichTextWrapper from '#/ui/shared/rich-text-wrapper';
 
-export default async function PrivacyPolicy() {
+export default async function EditorialPolicyPage() {
   const pageIntro = await fetchEditorialPageIntro();
   const privacy = await fetchEditorialPage();
   const { items: blogPosts } = await fetchBlogPosts({

--- a/apps/web/src/app/(site)/editorial/page.tsx
+++ b/apps/web/src/app/(site)/editorial/page.tsx
@@ -25,8 +25,8 @@ export default async function PrivacyPolicy() {
   });
 
   const pages = blogPosts.map((post) => ({
-    href: `/blog/${post._slug}`,
-    title: post._title,
+    href: `/blog/${post._sys.slug}`,
+    title: post._sys.title,
     description: post.metaDescription,
     readMoreButtonText: post.readMoreButtonText,
   }));

--- a/apps/web/src/app/(site)/faq/page.tsx
+++ b/apps/web/src/app/(site)/faq/page.tsx
@@ -31,8 +31,8 @@ export default async function FaqPage() {
   }
 
   const pages = blogPosts.map((post) => ({
-    href: `/blog/${post._slug}`,
-    title: post._title,
+    href: `/blog/${post._sys.slug}`,
+    title: post._sys.title,
     description: post.metaDescription,
     readMoreButtonText: post.readMoreButtonText,
   }));

--- a/apps/web/src/app/(site)/privacy/page.tsx
+++ b/apps/web/src/app/(site)/privacy/page.tsx
@@ -25,8 +25,8 @@ export default async function PrivacyPolicy() {
   });
 
   const pages = blogPosts.map((post) => ({
-    href: `/blog/${post._slug}`,
-    title: post._title,
+    href: `/blog/${post._sys.slug}`,
+    title: post._sys.title,
     description: post.metaDescription,
     readMoreButtonText: post.readMoreButtonText,
   }));

--- a/apps/web/src/app/(site)/privacy/page.tsx
+++ b/apps/web/src/app/(site)/privacy/page.tsx
@@ -17,7 +17,7 @@ import { PageIntro } from '#/ui/page-intro';
 import { PageLinks } from '#/ui/page-links';
 import RichTextWrapper from '#/ui/shared/rich-text-wrapper';
 
-export default async function PrivacyPolicy() {
+export default async function PrivacyPolicyPage() {
   const pageIntro = await fetchPrivacyPageIntro();
   const privacy = await fetchPrivacyPage();
   const { items: blogPosts } = await fetchBlogPosts({

--- a/apps/web/src/app/(site)/process/page.tsx
+++ b/apps/web/src/app/(site)/process/page.tsx
@@ -10,7 +10,7 @@ import { DiscoveryAssimilation } from '#/ui/process/discovery-assimilate';
 import { PlanningDefinition } from '#/ui/process/planning-definition';
 import { Values } from '#/ui/process/values';
 
-export default function Process() {
+export default function ProcessPage() {
   return (
     <>
       <PageIntro eyebrow="Our Secret Formula" title="Innovatively recycled">
@@ -33,7 +33,7 @@ export default function Process() {
   );
 }
 
-const title = 'Process';
+const title = 'The Process';
 const description =
   "Discover and be assimilated in our process at sambi.dev. Our secret formula? Stalking, re-purposing, and overcharging for stuff you probably don't need. 🤑";
 

--- a/apps/web/src/app/(site)/showcase/[slug]/page.tsx
+++ b/apps/web/src/app/(site)/showcase/[slug]/page.tsx
@@ -49,17 +49,17 @@ export default async function ProjectBriefPage({
     first: 10,
   });
 
-  const eyebrowText = `${brief.client._title} Project Brief${brief.isPartner ? ' :: Via partner' : ''}`;
+  const eyebrowText = `${brief.client._sys.title} Project Brief${brief.isPartner ? ' :: Via partner' : ''}`;
 
   const filteredShowcaseBriefs = moreShowcaseBriefs.filter(
-    (moreBrief) => moreBrief._id !== brief._id,
+    (moreBrief) => moreBrief._sys.id !== brief._sys.id,
   );
 
   const limitedShowcaseBriefs = filteredShowcaseBriefs.slice(0, 2);
 
   const formattedPages = limitedShowcaseBriefs.map((brief) => ({
-    href: `/showcase/${brief._slug}`,
-    title: brief._title,
+    href: `/showcase/${brief._sys.slug}`,
+    title: brief._sys.title,
     description: brief.metaDescription,
     readMoreButtonText: brief.readMoreButtonText,
   }));
@@ -68,7 +68,7 @@ export default async function ProjectBriefPage({
     <>
       <article className="mt-24 sm:mt-32 lg:mt-40">
         <header>
-          <PageIntro eyebrow={eyebrowText} title={brief._title} centered>
+          <PageIntro eyebrow={eyebrowText} title={brief._sys.title} centered>
             <p>{brief.metaDescription}</p>
           </PageIntro>
 
@@ -82,7 +82,7 @@ export default async function ProjectBriefPage({
                         Client
                       </dt>
                       <dd className="text-muted-foreground">
-                        {brief.client._title}
+                        {brief.client._sys.title}
                       </dd>
                     </div>
                     <div className="border-t px-6 py-4 first:border-t-0 sm:border-l sm:border-t-0">
@@ -90,8 +90,8 @@ export default async function ProjectBriefPage({
                         Year
                       </dt>
                       <dd className="text-muted-foreground">
-                        <time dateTime={brief.publishedDate.split('-')[0]}>
-                          {brief.publishedDate.split('-')[0]}
+                        <time dateTime={brief._sys.createdAt.split('-')[0]}>
+                          {brief._sys.createdAt.split('-')[0]}
                         </time>
                       </dd>
                     </div>
@@ -106,7 +106,7 @@ export default async function ProjectBriefPage({
                         Service
                       </dt>
                       <dd className="text-muted-foreground">
-                        {brief.service[0]?._title}
+                        {brief.service[0]?._sys.title}
                       </dd>
                     </div>
                   </dl>

--- a/apps/web/src/app/(site)/showcase/page.tsx
+++ b/apps/web/src/app/(site)/showcase/page.tsx
@@ -17,7 +17,7 @@ import { PageIntro } from '#/ui/page-intro';
 import { LoadMore, LoadMoreButton, LoadMoreItems } from '#/ui/shared/load-more';
 import { ProjectBriefs } from '#/ui/showcase/project-briefs';
 
-export default async function Work() {
+export default async function ShowcasePage() {
   const { items: initialProjectBriefs, totalCount } = await fetchShowcaseBriefs(
     { skip: 0, first: 10 },
   );

--- a/apps/web/src/app/(site)/stack/page.tsx
+++ b/apps/web/src/app/(site)/stack/page.tsx
@@ -13,8 +13,8 @@ export default async function StackPage() {
   });
 
   const pages = blogPosts.map((post) => ({
-    href: `/blog/${post._slug}`,
-    title: post._title,
+    href: `/blog/${post._sys.slug}`,
+    title: post._sys.title,
     description: post.metaDescription,
     readMoreButtonText: post.readMoreButtonText,
   }));

--- a/apps/web/src/app/(site)/terms/page.tsx
+++ b/apps/web/src/app/(site)/terms/page.tsx
@@ -25,8 +25,8 @@ export default async function PrivacyPolicy() {
   });
 
   const pages = blogPosts.map((post) => ({
-    href: `/blog/${post._slug}`,
-    title: post._title,
+    href: `/blog/${post._sys.slug}`,
+    title: post._sys.title,
     description: post.metaDescription,
     readMoreButtonText: post.readMoreButtonText,
   }));

--- a/apps/web/src/app/(site)/terms/page.tsx
+++ b/apps/web/src/app/(site)/terms/page.tsx
@@ -17,7 +17,7 @@ import { PageIntro } from '#/ui/page-intro';
 import { PageLinks } from '#/ui/page-links';
 import RichTextWrapper from '#/ui/shared/rich-text-wrapper';
 
-export default async function PrivacyPolicy() {
+export default async function TermsOfServicePage() {
   const pageIntro = await fetchTermsPageIntro();
   const privacy = await fetchTermsPage();
   const { items: blogPosts } = await fetchBlogPosts({

--- a/apps/web/src/basehub/accessibility-queries.ts
+++ b/apps/web/src/basehub/accessibility-queries.ts
@@ -6,9 +6,10 @@ export async function fetchAccessibilityPageMetadata() {
   const { accessibility } = await basehubClient.query({
     accessibility: {
       accessibilityPageMeta: {
-        _id: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         title: true,
         description: true,
       },
@@ -25,6 +26,10 @@ export async function fetchAccessibilityPageIntro() {
   const { accessibility } = await basehubClient.query({
     accessibility: {
       accessibilityPageIntro: {
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         eyebrow: true,
         title: true,
         description: {
@@ -48,16 +53,25 @@ export async function fetchAccessibilityPageIntro() {
 export async function fetchAccessibilityPage() {
   const { accessibility } = await basehubClient.query({
     accessibility: {
-      _id: true,
-      _slug: true,
-      _title: true,
+      _sys: {
+        id: true,
+        slug: true,
+        title: true,
+        createdAt: true,
+        lastModifiedAt: true,
+        __typename: true,
+      },
+      isPublished: true,
       content: {
         json: {
           content: true,
         },
       },
-      isPublished: true,
       accessibilityPageIntro: {
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         eyebrow: true,
         title: true,
         description: {
@@ -68,9 +82,11 @@ export async function fetchAccessibilityPage() {
         centered: true,
       },
       accessibilityPageMeta: {
-        _id: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          __typename: true,
+        },
+        title: true,
         description: true,
       },
     },

--- a/apps/web/src/basehub/ai-blog-queries.ts
+++ b/apps/web/src/basehub/ai-blog-queries.ts
@@ -89,7 +89,7 @@ export const aiBlogPostFragment = {
       __typename: true,
     },
     description: true,
-    isActive: true,
+    isPublished: true,
   },
   content: {
     json: {
@@ -174,10 +174,11 @@ export const getAiPostBySlugQuery = (slug: string) => {
             _sys: {
               id: true,
               title: true,
+              slug: true,
               __typename: true,
             },
             description: true,
-            isActive: true,
+            isPublished: true,
           },
           image: {
             url: true,

--- a/apps/web/src/basehub/ai-blog-queries.ts
+++ b/apps/web/src/basehub/ai-blog-queries.ts
@@ -13,9 +13,10 @@ export async function fetchAiBlogPageMetadata() {
   const { aiBlog } = await basehubClient.query({
     aiBlog: {
       aiBlogPageMeta: {
-        _id: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         title: true,
         description: true,
       },
@@ -34,6 +35,10 @@ export async function fetchAiBlogPageIntro() {
   const { aiBlog } = await basehubClient.query({
     aiBlog: {
       aiBlogPageIntro: {
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         eyebrow: true,
         title: true,
         description: {
@@ -55,12 +60,20 @@ export async function fetchAiBlogPageIntro() {
 }
 
 export const aiBlogPostFragment = {
-  _id: true,
-  _slug: true,
-  _title: true,
+  _sys: {
+    id: true,
+    slug: true,
+    title: true,
+    createdAt: true,
+    lastModifiedAt: true,
+    __typename: true,
+  },
   company: {
-    _id: true,
-    _title: true,
+    _sys: {
+      id: true,
+      title: true,
+      __typename: true,
+    },
     image: {
       url: true,
       alt: true,
@@ -69,10 +82,12 @@ export const aiBlogPostFragment = {
     version: true,
   },
   category: {
-    __typename: true,
-    _id: true,
-    _slug: true,
-    _title: true,
+    _sys: {
+      id: true,
+      slug: true,
+      title: true,
+      __typename: true,
+    },
     description: true,
     isActive: true,
   },
@@ -89,7 +104,6 @@ export const aiBlogPostFragment = {
   },
   metaTitle: true,
   metaDescription: true,
-  publishedDate: true,
   readMoreButtonText: true,
   tldr: {
     json: {
@@ -112,6 +126,7 @@ export async function fetchAiBlogPosts({ skip = 0, first = 10 } = {}) {
         __args: {
           skip,
           first,
+          orderBy: '_sys_createdAt__DESC',
         },
         items: aiBlogPostFragment,
         _meta: {
@@ -133,14 +148,21 @@ export const getAiPostBySlugQuery = (slug: string) => {
       aiBlogPosts: {
         __args: { first: 1, filter: { _sys_slug: { eq: slug } } },
         items: {
-          _id: true,
-          _slug: true,
-          _title: true,
-          publishedDate: true,
+          _sys: {
+            id: true,
+            slug: true,
+            title: true,
+            createdAt: true,
+            lastModifiedAt: true,
+            __typename: true,
+          },
           content: { json: { content: true } },
           company: {
-            _id: true,
-            _title: true,
+            _sys: {
+              id: true,
+              title: true,
+              __typename: true,
+            },
             model: true,
             version: true,
             image: {
@@ -149,8 +171,11 @@ export const getAiPostBySlugQuery = (slug: string) => {
             },
           },
           category: {
-            _id: true,
-            _title: true,
+            _sys: {
+              id: true,
+              title: true,
+              __typename: true,
+            },
           },
           image: {
             url: true,

--- a/apps/web/src/basehub/ai-blog-queries.ts
+++ b/apps/web/src/basehub/ai-blog-queries.ts
@@ -176,6 +176,8 @@ export const getAiPostBySlugQuery = (slug: string) => {
               title: true,
               __typename: true,
             },
+            description: true,
+            isActive: true,
           },
           image: {
             url: true,

--- a/apps/web/src/basehub/blog-queries.ts
+++ b/apps/web/src/basehub/blog-queries.ts
@@ -89,7 +89,7 @@ export const blogPostFragment = {
       __typename: true,
     },
     description: true,
-    isActive: true,
+    isPublished: true,
   },
   tldr: {
     json: {
@@ -182,7 +182,7 @@ export const getPostBySlugQuery = (slug: string) => {
               __typename: true,
             },
             description: true,
-            isActive: true,
+            isPublished: true,
           },
           image: {
             url: true,

--- a/apps/web/src/basehub/blog-queries.ts
+++ b/apps/web/src/basehub/blog-queries.ts
@@ -13,9 +13,10 @@ export async function fetchBlogPageMetadata() {
   const { blog } = await basehubClient.query({
     blog: {
       blogPageMeta: {
-        _id: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         title: true,
         description: true,
       },
@@ -34,6 +35,10 @@ export async function fetchBlogPageIntro() {
   const { blog } = await basehubClient.query({
     blog: {
       blogPageIntro: {
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         eyebrow: true,
         title: true,
         description: {
@@ -55,13 +60,21 @@ export async function fetchBlogPageIntro() {
 }
 
 export const blogPostFragment = {
-  _id: true,
-  _slug: true,
-  _title: true,
+  _sys: {
+    id: true,
+    slug: true,
+    title: true,
+    createdAt: true,
+    lastModifiedAt: true,
+    __typename: true,
+  },
   author: {
-    _id: true,
-    _slug: true,
-    _title: true,
+    _sys: {
+      id: true,
+      slug: true,
+      title: true,
+      __typename: true,
+    },
     image: {
       url: true,
       alt: true,
@@ -69,12 +82,19 @@ export const blogPostFragment = {
     role: true,
   },
   category: {
-    __typename: true,
-    _id: true,
-    _slug: true,
-    _title: true,
+    _sys: {
+      id: true,
+      slug: true,
+      title: true,
+      __typename: true,
+    },
     description: true,
     isActive: true,
+  },
+  tldr: {
+    json: {
+      content: true,
+    },
   },
   content: {
     json: {
@@ -89,13 +109,7 @@ export const blogPostFragment = {
   },
   metaTitle: true,
   metaDescription: true,
-  publishedDate: true,
   readMoreButtonText: true,
-  tldr: {
-    json: {
-      content: true,
-    },
-  },
 } satisfies BlogPostsItemGenqlSelection;
 
 export type BlogPostFragment = FieldsSelection<
@@ -110,8 +124,9 @@ export async function fetchBlogPosts({ skip = 0, first = 10 } = {}) {
     blog: {
       blogPosts: {
         __args: {
-          first,
           skip,
+          first,
+          orderBy: '_sys_createdAt__DESC',
         },
         items: blogPostFragment,
         _meta: {
@@ -133,14 +148,22 @@ export const getPostBySlugQuery = (slug: string) => {
       blogPosts: {
         __args: { first: 1, filter: { _sys_slug: { eq: slug } } },
         items: {
-          _id: true,
-          _slug: true,
-          _title: true,
-          publishedDate: true,
+          _sys: {
+            id: true,
+            slug: true,
+            title: true,
+            createdAt: true,
+            lastModifiedAt: true,
+            __typename: true,
+          },
           content: { json: { content: true } },
           author: {
-            _id: true,
-            _title: true,
+            _sys: {
+              id: true,
+              slug: true,
+              title: true,
+              __typename: true,
+            },
             bio: true,
             image: {
               url: true,
@@ -153,8 +176,13 @@ export const getPostBySlugQuery = (slug: string) => {
             linkedinUrl: true,
           },
           category: {
-            _id: true,
-            _title: true,
+            _sys: {
+              id: true,
+              title: true,
+              __typename: true,
+            },
+            description: true,
+            isActive: true,
           },
           image: {
             url: true,

--- a/apps/web/src/basehub/crew-queries.ts
+++ b/apps/web/src/basehub/crew-queries.ts
@@ -7,9 +7,14 @@ import type {
 import { basehubClient } from './client';
 
 export const crewFragment = {
-  _id: true,
-  _slug: true,
-  _title: true,
+  _sys: {
+    id: true,
+    slug: true,
+    title: true,
+    createdAt: true,
+    lastModifiedAt: true,
+    __typename: true,
+  },
   title: true,
   description: {
     json: {
@@ -18,9 +23,12 @@ export const crewFragment = {
   },
   people: {
     items: {
-      _id: true,
-      _slug: true,
-      _title: true,
+      _sys: {
+        id: true,
+        slug: true,
+        title: true,
+        __typename: true,
+      },
       bio: true,
       role: true,
       image: {

--- a/apps/web/src/basehub/editorial-queries.ts
+++ b/apps/web/src/basehub/editorial-queries.ts
@@ -6,9 +6,10 @@ export async function fetchEditorialPageMetadata() {
   const { editorial } = await basehubClient.query({
     editorial: {
       editorialPageMeta: {
-        _id: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         title: true,
         description: true,
       },
@@ -27,6 +28,10 @@ export async function fetchEditorialPageIntro() {
   const { editorial } = await basehubClient.query({
     editorial: {
       editorialPageIntro: {
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         eyebrow: true,
         title: true,
         description: {
@@ -52,16 +57,25 @@ export async function fetchEditorialPage() {
 
   const { editorial } = await basehubClient.query({
     editorial: {
-      _id: true,
-      _slug: true,
-      _title: true,
+      _sys: {
+        id: true,
+        slug: true,
+        title: true,
+        createdAt: true,
+        lastModifiedAt: true,
+        __typename: true,
+      },
+      isPublished: true,
       content: {
         json: {
           content: true,
         },
       },
-      isPublished: true,
       editorialPageIntro: {
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         eyebrow: true,
         title: true,
         description: {
@@ -72,9 +86,11 @@ export async function fetchEditorialPage() {
         centered: true,
       },
       editorialPageMeta: {
-        _id: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          __typename: true,
+        },
+        title: true,
         description: true,
       },
     },

--- a/apps/web/src/basehub/faq-queries.ts
+++ b/apps/web/src/basehub/faq-queries.ts
@@ -8,9 +8,10 @@ export async function fetchFaqsPageMetadata() {
   const { faqs } = await basehubClient.query({
     faqs: {
       faqsPageMeta: {
-        _id: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         title: true,
         description: true,
       },
@@ -29,6 +30,10 @@ export async function fetchFaqsPageIntro() {
   const { faqs } = await basehubClient.query({
     faqs: {
       faqsPageIntro: {
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         eyebrow: true,
         title: true,
         description: {
@@ -50,15 +55,21 @@ export async function fetchFaqsPageIntro() {
 }
 
 export const faqFragment = {
-  _id: true,
-  _slug: true,
-  _title: true,
+  _sys: {
+    id: true,
+    slug: true,
+    title: true,
+    createdAt: true,
+    lastModifiedAt: true,
+    __typename: true,
+  },
   items: {
-    _id: true,
-    _slug: true,
-    _title: true,
+    _sys: {
+      id: true,
+      title: true,
+      __typename: true,
+    },
     isPriority: true,
-    isActive: true,
     answer: {
       json: {
         content: true,

--- a/apps/web/src/basehub/privacy-queries.ts
+++ b/apps/web/src/basehub/privacy-queries.ts
@@ -6,9 +6,10 @@ export async function fetchPrivacyPageMetadata() {
   const { privacy } = await basehubClient.query({
     privacy: {
       privacyPageMeta: {
-        _id: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         title: true,
         description: true,
       },
@@ -27,6 +28,10 @@ export async function fetchPrivacyPageIntro() {
   const { privacy } = await basehubClient.query({
     privacy: {
       privacyPageIntro: {
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         eyebrow: true,
         title: true,
         description: {
@@ -52,9 +57,14 @@ export async function fetchPrivacyPage() {
 
   const { privacy } = await basehubClient.query({
     privacy: {
-      _id: true,
-      _slug: true,
-      _title: true,
+      _sys: {
+        id: true,
+        slug: true,
+        title: true,
+        createdAt: true,
+        lastModifiedAt: true,
+        __typename: true,
+      },
       content: {
         json: {
           content: true,
@@ -62,6 +72,10 @@ export async function fetchPrivacyPage() {
       },
       isPublished: true,
       privacyPageIntro: {
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         eyebrow: true,
         title: true,
         description: {
@@ -72,9 +86,11 @@ export async function fetchPrivacyPage() {
         centered: true,
       },
       privacyPageMeta: {
-        _id: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          __typename: true,
+        },
+        title: true,
         description: true,
       },
     },

--- a/apps/web/src/basehub/showcase-queries.ts
+++ b/apps/web/src/basehub/showcase-queries.ts
@@ -13,9 +13,10 @@ export async function fetchShowcasePageMetadata() {
   const { showcase } = await basehubClient.query({
     showcase: {
       showcasePageMeta: {
-        _id: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         title: true,
         description: true,
       },
@@ -34,6 +35,10 @@ export async function fetchShowcasePageIntro() {
   const { showcase } = await basehubClient.query({
     showcase: {
       showcasePageIntro: {
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         eyebrow: true,
         title: true,
         description: {
@@ -55,24 +60,36 @@ export async function fetchShowcasePageIntro() {
 }
 
 export const showcaseBriefFragment = {
-  _id: true,
-  _slug: true,
-  _title: true,
-  __typename: true,
-  client: {
-    _id: true,
-    _title: true,
-    _slug: true,
+  _sys: {
+    id: true,
+    slug: true,
+    title: true,
+    createdAt: true,
+    lastModifiedAt: true,
     __typename: true,
+  },
+  client: {
+    _sys: {
+      id: true,
+      title: true,
+      __typename: true,
+    },
     contacts: {
+      _sys: {
+        id: true,
+        title: true,
+        __typename: true,
+      },
       __args: {
         first: 1,
       },
       items: {
-        _id: true,
-        __typename: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          title: true,
+          slug: true,
+          __typename: true,
+        },
         firstName: true,
         lastInitial: true,
         role: true,
@@ -87,7 +104,7 @@ export const showcaseBriefFragment = {
       url: true,
       alt: true,
     },
-    isActive: true,
+    isPublished: true,
     logo: {
       url: true,
       alt: true,
@@ -105,13 +122,15 @@ export const showcaseBriefFragment = {
   },
   isPartner: true,
   isPublished: true,
-  publishedDate: true,
   metaTitle: true,
   metaDescription: true,
   readMoreButtonText: true,
   service: {
-    _id: true,
-    _title: true,
+    _sys: {
+      id: true,
+      title: true,
+      __typename: true,
+    },
   },
   status: true,
   summary: {
@@ -135,6 +154,7 @@ export async function fetchShowcaseBriefs({ skip = 0, first = 10 } = {}) {
         __args: {
           first,
           skip,
+          orderBy: '_sys_createdAt__DESC',
         },
         items: showcaseBriefFragment,
         _meta: {
@@ -158,7 +178,7 @@ export async function fetchRecentShowcaseBriefs() {
       brief: {
         __args: {
           first: 3,
-          orderBy: 'publishedDate__DESC',
+          orderBy: '_sys_createdAt__DESC',
         },
         items: showcaseBriefFragment,
       },
@@ -174,15 +194,27 @@ export const getShowcaseBriefBySlugQuery = (slug: string) => {
       brief: {
         __args: { first: 1, filter: { _sys_slug: { eq: slug } } },
         items: {
-          _id: true,
-          _slug: true,
-          _title: true,
-          publishedDate: true,
+          _sys: {
+            id: true,
+            slug: true,
+            title: true,
+            createdAt: true,
+            lastModifiedAt: true,
+            __typename: true,
+          },
           content: { json: { content: true } },
           client: {
-            _id: true,
-            _title: true,
+            _sys: {
+              id: true,
+              title: true,
+              __typename: true,
+            },
             contacts: {
+              _sys: {
+                id: true,
+                title: true,
+                __typename: true,
+              },
               __args: {
                 first: 1,
               },
@@ -193,7 +225,7 @@ export const getShowcaseBriefBySlugQuery = (slug: string) => {
               url: true,
               alt: true,
             },
-            isActive: true,
+            isPublished: true,
             logo: {
               url: true,
               alt: true,
@@ -201,8 +233,12 @@ export const getShowcaseBriefBySlugQuery = (slug: string) => {
             website: true,
           },
           service: {
-            _id: true,
-            _title: true,
+            _sys: {
+              id: true,
+              title: true,
+              slug: true,
+              __typename: true,
+            },
           },
           status: true,
           image: {

--- a/apps/web/src/basehub/terms-queries.ts
+++ b/apps/web/src/basehub/terms-queries.ts
@@ -6,9 +6,10 @@ export async function fetchTermsPageMetadata() {
   const { terms } = await basehubClient.query({
     terms: {
       termsPageMeta: {
-        _id: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         title: true,
         description: true,
       },
@@ -27,6 +28,10 @@ export async function fetchTermsPageIntro() {
   const { terms } = await basehubClient.query({
     terms: {
       termsPageIntro: {
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         eyebrow: true,
         title: true,
         description: {
@@ -52,16 +57,25 @@ export async function fetchTermsPage() {
 
   const { terms } = await basehubClient.query({
     terms: {
-      _id: true,
-      _slug: true,
-      _title: true,
+      _sys: {
+        id: true,
+        slug: true,
+        title: true,
+        createdAt: true,
+        lastModifiedAt: true,
+        __typename: true,
+      },
+      isPublished: true,
       content: {
         json: {
           content: true,
         },
       },
-      isPublished: true,
       termsPageIntro: {
+        _sys: {
+          id: true,
+          __typename: true,
+        },
         eyebrow: true,
         title: true,
         description: {
@@ -72,9 +86,11 @@ export async function fetchTermsPage() {
         centered: true,
       },
       termsPageMeta: {
-        _id: true,
-        _slug: true,
-        _title: true,
+        _sys: {
+          id: true,
+          __typename: true,
+        },
+        title: true,
         description: true,
       },
     },

--- a/apps/web/src/ui/about/crew.tsx
+++ b/apps/web/src/ui/about/crew.tsx
@@ -27,7 +27,7 @@ export default function Crew({ crew }: CrewProps) {
         <ul className="-mt-12 space-y-12 divide-y divide-border xl:col-span-3">
           {crew.people.items.map((person) => (
             <li
-              key={person._id}
+              key={person._sys.id}
               className="flex flex-col gap-10 pt-12 sm:flex-row"
             >
               <Image
@@ -35,17 +35,17 @@ export default function Crew({ crew }: CrewProps) {
                 src={person.image.url}
                 alt={
                   person.image.alt ??
-                  `A notion styled illustration representing a headshot of ${person._title}`
+                  `A notion styled illustration representing a headshot of ${person._sys.title}`
                 }
                 width={208}
                 height={260}
               />
               <div className="max-w-xl flex-auto">
                 <h3
-                  id={person._slug}
+                  id={person._sys.id}
                   className="font-mono font-semibold tracking-tighter text-foreground"
                 >
-                  {person._title}
+                  {person._sys.title}
                 </h3>
                 <p className="font-mono text-sm text-primary">{person.role}</p>
                 <p className="mt-6 text-sm leading-7 text-muted-foreground md:text-base">
@@ -59,7 +59,7 @@ export default function Crew({ crew }: CrewProps) {
                         icon={
                           <UpworkIcon className="h-6 w-6" aria-hidden="true" />
                         }
-                        label={`Follow ${person._title} on Upwork in a new window`}
+                        label={`Follow ${person._sys.title} on Upwork in a new window`}
                       />
                     </li>
                   )}
@@ -68,7 +68,7 @@ export default function Crew({ crew }: CrewProps) {
                       <CrewSocialIcon
                         url={person.twitterUrl}
                         icon={<XIcon className="h-6 w-6" aria-hidden="true" />}
-                        label={`Follow ${person._title} on Twitter in a new window`}
+                        label={`Follow ${person._sys.title} on Twitter in a new window`}
                       />
                     </li>
                   )}
@@ -82,7 +82,7 @@ export default function Crew({ crew }: CrewProps) {
                             aria-hidden="true"
                           />
                         }
-                        label={`Connect with ${person._title} on LinkedIn in a new window`}
+                        label={`Connect with ${person._sys.title} on LinkedIn in a new window`}
                       />
                     </li>
                   )}

--- a/apps/web/src/ui/home/showcase.tsx
+++ b/apps/web/src/ui/home/showcase.tsx
@@ -35,12 +35,15 @@ export function Showcase({
       <Container className="my-16">
         <FadeInStagger className="grid grid-cols-1 gap-8 lg:grid-cols-3">
           {projectBriefs.map((projectBrief) => (
-            <FadeIn key={`/showcase/${projectBrief._slug}`} className="flex">
+            <FadeIn
+              key={`/showcase/${projectBrief._sys.slug}`}
+              className="flex"
+            >
               <article className="relative flex w-full flex-col rounded-3xl border bg-card p-6 shadow-md transition hover:bg-primary/20 sm:p-8">
                 <h3>
                   <Link
-                    href={`/showcase/${projectBrief._slug}`}
-                    aria-label={`Read more about our work with ${projectBrief.client._title} now`}
+                    href={`/showcase/${projectBrief._sys.slug}`}
+                    aria-label={`Read more about our work with ${projectBrief.client._sys.title} now`}
                   >
                     <span className="absolute inset-0 rounded-3xl" />
                     <Image
@@ -56,14 +59,16 @@ export function Showcase({
                   </Link>
                 </h3>
                 <div className="mt-6 flex gap-x-2 font-mono text-xs font-medium tracking-tighter text-secondary-foreground">
-                  <p className=" text-primary">{projectBrief.client._title}</p>
+                  <p className=" text-primary">
+                    {projectBrief.client._sys.title}
+                  </p>
                   <span className="text-foreground" aria-hidden="true">
                     ::
                   </span>
-                  <span>{projectBrief.service[0]?._title}</span>
+                  <span>{projectBrief.service[0]?._sys.title}</span>
                 </div>
                 <p className="mt-6 grow text-pretty font-mono font-semibold tracking-tighter text-foreground">
-                  {projectBrief._title}
+                  {projectBrief._sys.title}
                 </p>
                 <p className="mt-4 line-clamp-2 text-sm text-muted-foreground">
                   {projectBrief.metaDescription}

--- a/apps/web/src/ui/shared/faq.tsx
+++ b/apps/web/src/ui/shared/faq.tsx
@@ -14,11 +14,11 @@ export default function Faqs({ faq }: FaqsProps) {
         <dl className="space-y-16 sm:grid sm:grid-cols-2 sm:gap-x-6 sm:gap-y-16 sm:space-y-0 lg:gap-x-10">
           {faq.items.map((item) => (
             <FadeIn
-              key={item._id}
+              key={item._sys.id}
               className="rounded-xl border bg-card p-6 shadow-md"
             >
               <dt className="font-mono text-lg font-semibold text-secondary-foreground">
-                {item._title}
+                {item._sys.title}
               </dt>
               <dd className="mt-2">
                 <RichTextWrapper

--- a/apps/web/src/ui/showcase/project-briefs.tsx
+++ b/apps/web/src/ui/showcase/project-briefs.tsx
@@ -22,7 +22,8 @@ export function ProjectBriefs({
 }) {
   const sortedProjectBriefs = projectBriefs.sort(
     (a, b) =>
-      new Date(b.publishedDate).getTime() - new Date(a.publishedDate).getTime(),
+      new Date(b._sys.createdAt).getTime() -
+      new Date(a._sys.createdAt).getTime(),
   );
 
   return (
@@ -34,7 +35,7 @@ export function ProjectBriefs({
       </FadeIn>
       <div className="mt-10 space-y-24">
         {sortedProjectBriefs.map((projectBrief) => (
-          <FadeIn key={projectBrief._id}>
+          <FadeIn key={projectBrief._sys.id}>
             <article>
               <Border className="grid grid-cols-3 gap-x-8 gap-y-8 pt-16">
                 <div className="col-span-full sm:flex sm:items-center sm:justify-between sm:gap-x-8 lg:col-span-1 lg:block">
@@ -51,7 +52,7 @@ export function ProjectBriefs({
                       unoptimized
                     />
                     <h3 className="mt-6 font-mono text-sm font-medium text-primary sm:mt-0 lg:mt-8">
-                      {projectBrief.client._title}
+                      {projectBrief.client._sys.title}
                     </h3>
                   </div>
                   <div className="mt-1 flex flex-row items-center gap-x-4 sm:mt-0">
@@ -59,13 +60,15 @@ export function ProjectBriefs({
                       {projectBrief.status}
                     </p>
                     <p className="font-mono text-xs text-muted-foreground lg:mt-2">
-                      <time dateTime={projectBrief.publishedDate.split('-')[0]}>
-                        {projectBrief.publishedDate.split('-')[0]}
+                      <time
+                        dateTime={projectBrief._sys.createdAt.split('-')[0]}
+                      >
+                        {projectBrief._sys.createdAt.split('-')[0]}
                       </time>
                     </p>
                   </div>
                   <p className="font-mono text-xs text-muted-foreground lg:mt-2">
-                    {projectBrief.service[0]?._title}
+                    {projectBrief.service[0]?._sys.title}
                   </p>
                 </div>
 
@@ -76,8 +79,8 @@ export function ProjectBriefs({
                     </div>
                   )}
                   <p className="text-pretty font-mono text-3xl font-semibold leading-normal tracking-tighter text-foreground hover:text-primary">
-                    <Link href={`/showcase/${projectBrief._slug}`}>
-                      {projectBrief._title}
+                    <Link href={`/showcase/${projectBrief._sys.slug}`}>
+                      {projectBrief._sys.title}
                     </Link>
                   </p>
                   <div className="my-6 space-y-6 text-base text-muted-foreground">
@@ -85,8 +88,8 @@ export function ProjectBriefs({
                   </div>
                   <div className="my-8 flex">
                     <Link
-                      href={`/showcase/${projectBrief._slug}`}
-                      aria-label={`Read project brief: ${projectBrief.client._title}`}
+                      href={`/showcase/${projectBrief._sys.slug}`}
+                      aria-label={`Read project brief: ${projectBrief.client._sys.title}`}
                       className={cn(
                         buttonVariants({ variant: 'secondary', size: 'sm' }),
                       )}


### PR DESCRIPTION
- removed direct access for _sys fields
- added _sys object to all queries
  - minimal to nested
  - full to document
- removed published date on basehub in lieu of sys date
- added descencding sort by created date
- made formatting of queries consistent
- updated page links globally to new sys fields
- cleaned up a bunch of copy 🍝 issues , 💩
- style: editing page links titles on blogs
- fixed the slug patterns for recently published showcase items
  - `project-name` or `client-name` **not** `project-brief-title-goes-here`
  
 Closes #116, closes #148, closes #149